### PR TITLE
Allow posting to slack on Sundays

### DIFF
--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -9,7 +9,7 @@ class SlackPoster
     @team_channel = team_channel
     @mood = mood
     @today = Date.today
-    @postable_day = !today.saturday? && !today.sunday?
+    @postable_day = !today.saturday?
     mood_hash
     channel
     create_poster


### PR DESCRIPTION
Currently the seal is not posting on Sundays, but team members in Israel are not receiving notifications. Since the script is posting on Fridays, we should post on Sundays as well