### PR TITLE
Add infra team to angry seal slacking to #infrastructure-intern

### DIFF
--- a/config/grabcad.yml
+++ b/config/grabcad.yml
@@ -2,7 +2,6 @@
 
 deathclaw:
   members:
-    - hmak3d
     - evan-grabcad
     - Maxodactyl
     - caseprince
@@ -115,3 +114,12 @@ alpha:
     
   channel:
     "#alpha"
+
+infra:
+  members:
+    - ebgc
+    - gp42
+    - hmak3d
+
+  channel:
+    "#infrastructure-intern"


### PR DESCRIPTION
Slack #infrastructure-intern channel when there are GrabCAD PRs

Run nightly by TeamCity [AngrySeal job](https://teamcity.grabcad.net/viewType.html?buildTypeId=PrintServiceProjects_CiHelpers_LighthouseAngrySeal)